### PR TITLE
build: fix build error with flint 3.2.0

### DIFF
--- a/src/FLINT_Integer.hh
+++ b/src/FLINT_Integer.hh
@@ -22,8 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "globals.hh"
 
-#include <flint/fmpz.h>
 #include <gmp.h>
+#include <flint/fmpz.h>
 #include <cassert>
 #include <cstdlib>
 #include <iostream>


### PR DESCRIPTION
```
$ make V=0
  CXX      FLINT_Integer.lo
In file included from FLINT_Integer.cc:22:
FLINT_Integer.hh: In constructor 'pplite::FLINT_Integer::FLINT_Integer(const __mpz_struct*)':
FLINT_Integer.hh:110:25: error: 'fmpz_set_mpz' was not declared in this scope; did you mean 'fmpz_get_mpn'?
  110 |     : FLINT_Integer() { fmpz_set_mpz(mp, z); }
```

fmpz.h / fmpq.h evaluate the presence of the gmp-internal macro ``__GMP_H__``, so there is a mandatory order for header files :-/